### PR TITLE
Adjust aspect ratio of desktop + update Stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,12 +1,12 @@
 {
+  "extends": "stylelint-config-recommended-scss",
+  "customSyntax": "postcss-scss",
   "plugins": [
     "stylelint-scss"
   ],
-  "extends": "stylelint-config-standard",
   "rules": {
     "at-rule-no-unknown": null,
     "scss/at-rule-no-unknown": true,
-    "string-quotes": "single",
     "font-family-name-quotes": null
   }
 }

--- a/desktop.html
+++ b/desktop.html
@@ -7,9 +7,12 @@
     <meta property="og:title" content="Desktop" />
     <meta property="og:url" content="https://dadhoc.net/desktop.html" />
     <meta name="og:description" content="Main page of dadhoc.net." />
-    <meta property="og:image" content="https://dadhoc.net/assets/images/thumbs/dadhoc.png" />
+    <meta
+      property="og:image"
+      content="https://dadhoc.net/assets/images/thumbs/dadhoc.png"
+    />
     <meta property="og:type" content="website" />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="/styles/components/desktop/style.css" />
     <link rel="icon" type="image/png" href="/assets/Images/favicon.png" />
     <!-- Scripts -->
@@ -21,9 +24,8 @@
 
   <body>
     <div class="wrapper">
-      <div class="wrapperinner">
+      <div class="desktop">
         <h1 align="center">WELCOME TO DADHOC.NET</h1>
-
         <main class="desktopmain">
           <!-- first column -->
           <section>
@@ -36,16 +38,14 @@
                 <p>[Writing]</p>
               </a>
             </div>
-            
             <!-- Photography -->
             <div class="icon">
-              <a href="/photography/photographyindex.html" >
+              <a href="/photography/photographyindex.html">
                 <img src="/assets/images/icons/photo.png" />
                 <p alt-text="Photography">My Pictures</p>
                 <p>[Photography]</p>
               </a>
             </div>
-
             <!-- Campfire -->
             <div class="icon">
               <a href="/sharedwriting.html">
@@ -53,7 +53,6 @@
                 <p alt-text="Campfire">Campfire.txt</p>
               </a>
             </div>
-
             <!-- Bluesky -->
             <div class="icon">
               <a
@@ -66,7 +65,6 @@
                 <p>[External Link]</p>
               </a>
             </div>
-
             <!-- GitHub -->
             <div class="icon">
               <a
@@ -79,7 +77,6 @@
                 <p>[External Link]</p>
               </a>
             </div>
-
             <!-- Instagram -->
             <div class="icon">
               <a
@@ -92,7 +89,6 @@
                 <p>[External Link]</p>
               </a>
             </div>
-
             <!-- KoFi -->
             <div class="icon">
               <a
@@ -105,7 +101,6 @@
                 <p>[External Link]</p>
               </a>
             </div>
-            
             <!-- About -->
             <div class="icon">
               <a href="/about.html">
@@ -113,7 +108,6 @@
                 <p alt-text="About">About.nfo</p>
               </a>
             </div>
-
             <!-- Updates -->
             <div class="icon">
               <a href="/updates.html">
@@ -122,17 +116,13 @@
               </a>
             </div>
           </section>
-          
           <!-- second column -->
           <section>
             <!-- Icons -->
           </section>
-          <section style="width: 100%;">
-          </section>
-          </main>
-
+        </main>
         <!-- Taskbar -->
-        <div class="taskbar">
+        <footer class="taskbar">
           <!-- Start Menu (Desktop) -->
           <a
             href="/desktop.html"
@@ -241,7 +231,7 @@
             />
             <p style="margin-left: 0.4rem; margin-right: 0.4rem">KOFI</p>
           </a>
-        </div>
+        </footer>
       </div>
     </div>
   </body>

--- a/package.json
+++ b/package.json
@@ -1,12 +1,20 @@
 {
-  "dependencies": {
-    "doiuse": "^4.4.1",
-    "scss": "^0.2.4",
-    "stylelint": "^14.14.1"
+  "name": "dadhoc.github.io",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Dadhoc's personal website",
+  "scripts": {
+    "stylelint": "stylelint \"**/*.scss\" postcss-scss",
+    "stylelint:fix": "stylelint \"**/*.scss\" postcss-scss --fix"
   },
   "devDependencies": {
-    "stylelint-config-recommended": "^9.0.0",
-    "stylelint-config-standard": "^29.0.0",
-    "stylelint-scss": "^4.3.0"
+    "doiuse": "^6.0.5",
+    "postcss-scss": "^4.0.9",
+    "scss": "^0.2.4",
+    "stylelint": "^16.19.1",
+    "stylelint-config-recommended": "^16.0.0",
+    "stylelint-config-recommended-scss": "^14.1.0",
+    "stylelint-config-standard": "^38.0.0",
+    "stylelint-scss": "^6.12.0"
   }
 }

--- a/styles/components/desktop/_desktop.scss
+++ b/styles/components/desktop/_desktop.scss
@@ -1,59 +1,57 @@
 @use "../../helpers/variables" as *;
 
 .wrapper {
-  display: grid;
-  &inner {
-    display: flex;
-    flex-flow: column;
-    padding-left: 2vw;
-    padding-right: 2vw;
-    padding-top: 2vh;
-  }
+  display: flex;
+  flex-flow: column wrap;
+  place-content: center;
+  place-items: center;
+  // top right bottom left
+  padding: 2rem 2rem 0;
+  // This is to make the wrapper big enough to center it in the middle of the screen
+  min-height: 90vh;
 }
 
 // Desktop styling
-
 .desktop {
-  display: block;
   background-color: $teal;
   font-family: "W95FA", monospace;
-  //max-height: 95vh;
+  aspect-ratio: 4/3;
+  // Tinker with width and height to get the right size
+  max-width: 75vw;
 
   &main {
-    display: grid;
+    display: flex;
     background-color: $teal;
     justify-content: start;
+    aspect-ratio: 4/3;
 
     section {
       display: flex;
-      flex-direction: column;
+      flex-flow: column wrap;
       align-items: center;
       justify-content: center;
       flex-wrap: wrap;
-      padding: 1rem;
-      max-height: 75vh;
-      margin: auto;
     }
   }
 
-  &sub {
-    display: grid;
-    background-color: $teal;
-    font-family: "W95FA", monospace;
-    justify-content: center;
+  // &sub {
+  //   display: grid;
+  //   background-color: $teal;
+  //   font-family: "W95FA", monospace;
+  //   justify-content: center;
 
-    section {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      padding: 1rem;
-      max-height: 75vh;
-      margin: auto;
-      width: auto;
-      aspect-ratio: 4/3;
-    }
-  }
+  //   section {
+  //     display: flex;
+  //     flex-direction: column;
+  //     align-items: center;
+  //     justify-content: center;
+  //     padding: 1rem;
+  //     max-height: 75vh;
+  //     margin: auto;
+  //     width: auto;
+  //     aspect-ratio: 4/3;
+  //   }
+  // }
 }
 
 .icon {
@@ -96,7 +94,6 @@
     justify-content: center;
     align-items: center;
     border-style: inset;
-
     background: $taskbarmid;
     padding: 0.1rem;
   }
@@ -108,7 +105,6 @@
     align-items: center;
     border-style: outset;
     max-height: 1.45rem;
-
     background: $taskbardark;
     padding: 0.1rem;
   }
@@ -119,10 +115,8 @@
 .windowheader {
   display: flex;
   flex-direction: row;
-  justify-items: stretch;
+  place-items: center stretch;
   justify-content: space-between;
-  align-items: center;
-
   background: $windowheader;
   width: 100%;
   height: 1.5rem;
@@ -148,12 +142,12 @@
   border: 5px;
   padding: 5px;
   max-height: fit-content;
-
   justify-self: center;
-
-  box-shadow: inset -1px -1px black, inset -2px -2px $taskbarmid,
-    inset 1px 1px $taskbarlight, inset 2px 2px $taskbarmid;
-
+  box-shadow:
+    inset -1px -1px black,
+    inset -2px -2px $taskbarmid,
+    inset 1px 1px $taskbarlight,
+    inset 2px 2px $taskbarmid;
   background-color: $taskbardark;
 
   .content {
@@ -200,11 +194,9 @@
   flex-direction: row;
   justify-content: center;
   align-items: flex-end;
-
   background: $taskbardark;
   width: 100%;
   height: 1.5rem;
-
   padding-top: 2px;
 
   &inset {
@@ -213,7 +205,6 @@
     justify-content: center;
     align-items: flex-end;
     border-style: inset;
-
     background: $taskbarmid;
     width: 100%;
     height: 1rem;
@@ -242,8 +233,11 @@
   color: black;
   // text-shadow: 1px 1px 1px white;
 
-  box-shadow: inset -1px -1px black, inset -2px -2px $taskbarmid,
-    inset 1px 1px $taskbarlight, inset 2px 2px $taskbarmid;
+  box-shadow:
+    inset -1px -1px black,
+    inset -2px -2px $taskbarmid,
+    inset 1px 1px $taskbarlight,
+    inset 2px 2px $taskbarmid;
 
   // States
 
@@ -252,7 +246,10 @@
   }
 
   &:active {
-    box-shadow: inset 1px 1px black, inset 2px 2px $taskbarmid,
-      inset -1px -1px $taskbarlight, inset -2px -2px $taskbarmid;
+    box-shadow:
+      inset 1px 1px black,
+      inset 2px 2px $taskbarmid,
+      inset -1px -1px $taskbarlight,
+      inset -2px -2px $taskbarmid;
   }
 }

--- a/styles/components/desktop/style.scss
+++ b/styles/components/desktop/style.scss
@@ -1,3 +1,3 @@
-@use '../../global/main';
-@use './desktop';
-@use '../startmenu/startmenu';
+@use "../../global/main";
+@use "./desktop";
+@use "../startmenu/startmenu";

--- a/styles/components/splash/_post.scss
+++ b/styles/components/splash/_post.scss
@@ -1,4 +1,4 @@
-@use "../../helpers/variables" as *;
+@use '../../helpers/variables' as *;
 
 $white: #fdffff;
 $red: red;
@@ -11,7 +11,7 @@ $red: red;
 .postlogo {
   display: flex;
   flex-direction: column;
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   align-items: flex-start;
   white-space: wrap;
   width: 95vw;
@@ -24,10 +24,18 @@ $red: red;
   }
 }
 
+.postbuttons {
+  font-size: 1.65rem;
+
+  a {
+    font-size: 1rem;
+  }
+}
+
 .post {
   display: flex;
   padding: 0 3rem;
-  
+
   p {
     color: $white;
     font-family: monospace;
@@ -36,12 +44,11 @@ $red: red;
     a {
       text-decoration: none;
     }
-   
   }
 
   a {
     text-decoration: none;
-  
+
     &:visited {
       color: hsl(0deg 100% 30%);
     }
@@ -67,7 +74,6 @@ $red: red;
 
   .horizontal {
     display: flex;
-    
   }
 
   .blink {
@@ -76,14 +82,6 @@ $red: red;
 
   .blinkwhite {
     animation: blinkerwhite 3s step-start infinite;
-  }
-}
-
-.postbuttons {
-  font-size: 1.65rem;
-
-  a {
-    font-size: 1rem;
   }
 }
 
@@ -97,22 +95,20 @@ footer {
   flex-direction: column;
   align-items: center;
   padding: 5px;
- 
+
   p {
-  color: #000080;
-  text-align: center;
-  font-weight: bold;
-  font-family:monospace;
-  font-size: 1rem;
-  width: 95px;
-  height: 1.3rem;
-  background-color: $taskbardark;
+    color: #000080;
+    text-align: center;
+    font-weight: bold;
+    font-family: monospace;
+    font-size: 1rem;
+    width: 95px;
+    height: 1.3rem;
+    background-color: $taskbardark;
   }
-  
 }
 
 // Keyframes
-
 @keyframes blinker {
   25% {
     opacity: 0;
@@ -151,14 +147,14 @@ footer {
   }
 }
 
-#post{
+#post {
   background-color: black;
-  font-family: "W95FA";
+  font-family: 'W95FA', monospace;
 }
 
-#error{
+#error {
   background: #000080;
-  font-family: "W95FA";
+  font-family: 'W95FA', monospace;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -168,5 +164,4 @@ footer {
   margin: auto;
   width: auto;
   aspect-ratio: 4/3;
-
 }

--- a/styles/components/splash/style.scss
+++ b/styles/components/splash/style.scss
@@ -1,2 +1,2 @@
-@import "../../global/main";
-@import "./post";
+@import url("../../global/main");
+@import url("./post");

--- a/styles/components/startmenu/_startmenu.scss
+++ b/styles/components/startmenu/_startmenu.scss
@@ -1,21 +1,16 @@
 @use "../../helpers/variables" as *;
 
 // Start Menu elements
-
 //.StartButton {}
 
 #StartMenu {
-    min-width: 15rem;
-    min-height: fit-content;
-    padding: 5px;
-  
-    text-align: center;
-    background-color: $taskbarmid;
-    display: none;
-    z-index: 9;
-    position: sticky;
-    top: 10rem;
-    
-  }
-  
-  
+  min-width: 15rem;
+  min-height: fit-content;
+  padding: 5px;
+  text-align: center;
+  background-color: $taskbarmid;
+  display: none;
+  z-index: 9;
+  position: sticky;
+  top: 10rem;
+}

--- a/styles/global/_main.scss
+++ b/styles/global/_main.scss
@@ -1,4 +1,5 @@
 @use "../helpers/variables" as *;
+@use "./reset";
 
 body {
   background-image: $body-bg-image;

--- a/styles/global/_reset.scss
+++ b/styles/global/_reset.scss
@@ -1,0 +1,77 @@
+/* 1. Use a more-intuitive box-sizing model */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/* 2. Remove default margin */
+* {
+  margin: 0;
+}
+
+/* 3. Enable keyword animations */
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    interpolate-size: allow-keywords;
+  }
+}
+
+body {
+  /* 4. Add accessible line-height */
+  line-height: 1.5;
+
+  /* 5. Improve text rendering */
+  -webkit-font-smoothing: antialiased;
+}
+
+/* 6. Improve media defaults */
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+/* 7. Inherit fonts for form controls */
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+/* 8. Avoid text overflows */
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}
+
+/* 9. Improve line wrapping */
+p {
+  text-wrap: pretty;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-wrap: balance;
+}
+
+/*
+  10. Create a root stacking context
+*/
+#root,
+#__next {
+  isolation: isolate;
+}

--- a/styles/helpers/_variables.scss
+++ b/styles/helpers/_variables.scss
@@ -4,7 +4,7 @@ $white: #fdffff;
 $taskbardark: #c0c0c0;
 $taskbarmid: #d8d8d8;
 $taskbarlight: #ebebeb;
-$windowheader: linear-gradient(0.25turn, #000080, #0F83CF);
+$windowheader: linear-gradient(0.25turn, #000080, #0f83cf);
 
 /* Background images */
 $favicon: url("/assets/images/favicon.png");


### PR DESCRIPTION
A PR for adding a 4:3 aspect ratio to the desktop elements and to keep stylelint up to date.

tl;dr I hate css

## Desktop
- "Moved" desktop div into the spot of wrapper inner, placing the taskbar and title within
- Added `aspect-ratio: 4/3` to `.wrapper` and `.desktop`
- Added `max-width: 75vw` to avoid the "supersized" desktop; adjust the max-width (and possibly max-height) to your taste
- Changed `.wrapper` padding from vh/vw to rem for consistency
- Commented out unused code

## Stylelint
- Updated Stylelint and stylelint packages to latest versions
- Added stylelint script
- Ran .scss linter on project

## Other
- Added `_reset.scss` to prevent css default styles from creating future fuckery; this may subtly impact current styles

